### PR TITLE
Exclude .svelte from lint target

### DIFF
--- a/packages/web/build/webpack.development.js
+++ b/packages/web/build/webpack.development.js
@@ -5,7 +5,7 @@ module.exports = {
     rules: [
       {
         enforce: 'pre',
-        test: /\.(js|svelte)$/,
+        test: /\.(js)$/,
         exclude: [/node_modules/, path.resolve(__dirname, '../../core')],
         loader: 'eslint-loader'
       },


### PR DESCRIPTION
Got weird error. I have no idea how to address this.

```
29:51  error  Delete `⏎);(`  prettier/prettier
```